### PR TITLE
Read Apple ID details from environment

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -8625,10 +8625,12 @@ device_sideloader() {
     echo "$latest" > ../saved/Sideloader_version
     device_pair
     log "Launching Dadoum Sideloader"
-    log "Enter Apple ID details to continue."
-    print "* Your Apple ID and password will only be sent to Apple servers."
-    local apple_id
-    local apple_pass
+    local apple_id="$APPLE_ID_USER"
+    local apple_pass="$APPLE_ID_PWD"
+    if [[ -z $apple_id || -z $apple_pass ]]; then
+        log "Enter Apple ID details to continue."
+        print "* Your Apple ID and password will only be sent to Apple servers."
+    fi
     while [[ -z $apple_id ]]; do
         read -p "$(input 'Apple ID: ')" apple_id
     done


### PR DESCRIPTION
When sideloading, you get asked for the Apple ID details every time to export them as environment variables for the sideloader.
This PR makes it skip the prompt if those variables are already defined, allowing you to set the details beforehand to make it a bit less annoying if you need to run the function often.