### PR TITLE
Run internet check with root

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -12259,7 +12259,7 @@ main() {
         local timeout="-w3"
         [[ $platform == "macos" ]] && timeout="-t3"
         for i in "${try[@]}"; do
-            ping -c1 $timeout $i | sed -n '1,2p'
+            sudo ping -c1 $timeout $i | sed -n '1,2p'
             check=${PIPESTATUS[0]}
             if [[ $check == 0 ]]; then
                 break


### PR DESCRIPTION
When trying to run on Debian Forky, the following happens:
```
 *** Legacy iOS Kit ***
 - Script by LukeZGD -

* Version: v26.07.18 (0ad7d06)
[Log] gio detected. Unmounting all iOS devices with it
* Enter your user password when prompted
* Your password input may not be visible, but it is still being entered.
[sudo] password for ivy: 
[Log] Running usbmuxd
[Log] Running on platform: linux (Debian GNU/Linux forky/sid - x86_64)
[Log] Checking Internet connection...
ping: socktype: SOCK_RAW
ping: socket: Operation not permitted
ping: => missing cap_net_raw+p capability or setuid?
ping: socktype: SOCK_RAW
ping: socket: Operation not permitted
ping: => missing cap_net_raw+p capability or setuid?
ping: socktype: SOCK_RAW
ping: socket: Operation not permitted
ping: => missing cap_net_raw+p capability or setuid?
[Error] Please check your Internet connection before proceeding.


[Log] Terminating own usbmuxd instance(s)
* Enter your user password when prompted
* Your password input may not be visible, but it is still being entered.

* Save the terminal output now if needed. (macOS: Cmd+S, Linux: Ctrl+Shift+S)
* Legacy iOS Kit v26.07.18 (0ad7d06)
* Platform: linux (Debian GNU/Linux forky/sid - x86_64) 
ivy@debian:~/GitHub/Legacy-iOS-Kit$ 
```
For whatever, on Forky (and potentially other versions of Debian), ping won't work unless it is run as root. To fix this, just run ping as root for the internet check.