### PR TITLE
Fix DRA v6 battery images

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -5769,6 +5769,41 @@ ipsw_prepare_powder() {
             ;;
         esac
     fi
+    # battery fix drav6
+    if [[ $device_target_drav6 == 1 ]]; then
+        log "dra v6: restoring complete original/base iOS battery graphics set"
+        device_fw_key_check base
+        device_fw_key_check target
+        mkdir -p "$all_flash"
+        local battery_comp
+        local battery_base_name
+        local battery_target_name
+        for battery_comp in BatteryCharging0 BatteryCharging1 BatteryFull BatteryLow0 BatteryLow1 GlyphCharging GlyphPlugin; do
+            battery_base_name=$(echo "$device_fw_key_base" | $jq -j '.keys[] | select(.image == "'"$battery_comp"'") | .filename')
+            battery_target_name=$(echo "$device_fw_key" | $jq -j '.keys[] | select(.image == "'"$battery_comp"'") | .filename')
+            if [[ -z $battery_base_name ]]; then
+                warn "dra v6: unable to find base $battery_comp; leaving existing image unchanged"
+                continue
+            fi
+            [[ -z $battery_target_name ]] && battery_target_name="$battery_base_name"
+
+            rm -f "$battery_base_name" "$battery_target_name"
+            file_extract_from_archive "$ipsw_base_path.ipsw" "$all_flash/$battery_base_name"
+            if [[ ! -s $battery_base_name ]]; then
+                warn "dra v6: failed to extract base $battery_comp ($battery_base_name); leaving existing image unchanged"
+                continue
+            fi
+
+            # add original image under both names
+            cp "$battery_base_name" "$all_flash/$battery_base_name"
+            if [[ $battery_target_name != "$battery_base_name" ]]; then
+                cp "$battery_base_name" "$all_flash/$battery_target_name"
+            fi
+            rm -f "$battery_base_name"
+        done
+        zip -r0 temp.ipsw "$all_flash"/*
+    fi
+
     ipsw_prepare_logos_add
     ipsw_bbreplace
 


### PR DESCRIPTION
This is the patch I mentioned in https://github.com/LukeZGD/Legacy-iOS-Kit/issues/1170. For dra v6 restores, this makes the battery images use the ones from hte base ipsw instead of the target ipsw. I first tried using the base BatteryLow0/1 and BatteryCharging0/1. That fixed the dead battery screen, but the plugged in charging screen was completely green. Using the full battery image set from base ipsw fixed both. This uses the base versions of:
• BatteryLow0
•BatteryLow1
•BatteryCharging0
•BatteryCharging1
•BatteryFull
•GlyphCharging
•GlyphPlugin

Tested on my 4s and both the dead battery and plugged in charging screens work correctly now. The patch starts at line 5772 with # battery fix drav6.
Fixes https://github.com/LukeZGD/Legacy-iOS-Kit/issues/1170